### PR TITLE
Update internals to consume 'singly-linked-list' default export

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@
 
     // singly linked-list to use at each hash value to mitigate
     // hash collisions
-    var LinkedList = require('singly-linked-list');
+    var LinkedList = require('singly-linked-list').default;
 
     // lodash utility module
     var _isEqual = require('lodash.isequal');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "simple-hashtable",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Javascript implementation of a simple hash table data structure",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
The `singly-linked-list` package updated to typescript, so to correctly consume the dependency, we need to explicitly reference the `default` export.

There might be a better way, but for now, the test suite is passing. This will also be refactored to typescript soon, so we can explore other options then if required.

Fixes #11 